### PR TITLE
added check to see if outputStream is a function and to initialize it if it is

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var PLUGIN_NAME = 'gulp-tape';
 
 var gulpTape = function(opts) {
   opts = opts || {};
+
   var outputStream = opts.outputStream || process.stdout;
   var files = [];
   var transform = function(file, encoding, cb) {
@@ -24,7 +25,13 @@ var gulpTape = function(opts) {
   };
   var flush = function(cb) {
     try {
-      tape.createStream().pipe(outputStream);
+      if (outputStream === process.stdout) {
+        tape.createStream().pipe(outputStream);
+      } else if (typeof outputStream === 'function') {
+        tape.createStream().pipe(outputStream()).pipe(process.stdout);
+      } else {
+        tape.createStream().pipe(outputStream).pipe(process.stdout);
+      }
       forEach(files, function(file) {
         requireUncached(file);
       });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ var gulpTape = function(opts) {
   opts = opts || {};
 
   var outputStream = opts.outputStream || process.stdout;
-  var files = [];
+  var reporter     = opts.reporter     || through.obj();
+  var files        = [];
+
   var transform = function(file, encoding, cb) {
     if (file.isNull()) {
       return cb(null, file);
@@ -23,15 +25,10 @@ var gulpTape = function(opts) {
     files.push(file.path);
     cb(null, file);
   };
+
   var flush = function(cb) {
     try {
-      if (outputStream === process.stdout) {
-        tape.createStream().pipe(outputStream);
-      } else if (typeof outputStream === 'function') {
-        tape.createStream().pipe(outputStream()).pipe(process.stdout);
-      } else {
-        tape.createStream().pipe(outputStream).pipe(process.stdout);
-      }
+      tape.createStream().pipe(reporter).pipe(outputStream);
       forEach(files, function(file) {
         requireUncached(file);
       });
@@ -40,6 +37,7 @@ var gulpTape = function(opts) {
       cb(new PluginError(PLUGIN_NAME, err));
     }
   };
+
   return through.obj(transform, flush);
 };
 


### PR DESCRIPTION
In reporters such as https://github.com/scottcorgan/tap-spec and https://github.com/substack/tap-colorize I found that passing through the streams generated by them as the `outputStream` parameter did not work, and gulp-tape basically failed silently. This is what I had before:

```
var tapSpec = require('tap-spec');
return gulp.src('testsout/**/*.js')
             .pipe(tape({
               outputStream: tapSpec()
             }));
```

Reporters like this need to be piped to `process.stdout` after they are run as well to actually show in the console output.

I added a check to see whether `opts.outputStream` is a function, and to run the function if it is before piping the results to `process.stdout`. I also changed the regular `outputStream` pipe to `process.stdout` after it is run as well. This now works correctly:

```
var tapSpec = require('tap-spec');
return gulp.src('testsout/**/*.js')
             .pipe(tape({
               outputStream: tapSpec
             }));
```
