### PR TITLE
refactor: use child_process.spawn instead of require-uncached

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ var tape = require('gulp-tape');
 Install via [npm](https://npmjs.com/):
 
 ```
-$ npm i --save gulp-tape
+$ npm i --save gulp-tape tape
 ```
 
 ## License

--- a/fork.js
+++ b/fork.js
@@ -1,0 +1,55 @@
+var vm = require('vm');
+var m = require('module');
+var path = require('path');
+var merge = require('lodash.merge');
+
+var keysBefore = Object.keys(global);
+
+/**
+ * patch node's require for execution in vm.runInThisContext
+ * @param  {string} dirName __dirname to emulate in the executed script
+ * @return {function}       patched require function
+ */
+function patchRequire(dirName, fileMap) {
+  return function patchedRequire(moduleName) {
+    if (moduleName[0] === '.') {
+      var resolved = path.resolve(dirName, moduleName);
+
+      if (fileMap[resolved]) {
+        try {
+          var script = vm.runInThisContext(m.wrap(fileMap[resolved]), resolved).bind(global);
+          script(exports, patchRequire(dirName, fileMap), module, resolved, dirName);
+          return module.exports;
+        } catch (err) {
+          console.error(err);
+          throw new err;
+        }
+      } else {
+        return require(resolved);
+      }
+    } else {
+      return require(moduleName);
+    }
+  };
+}
+
+var args = process.argv.slice(2);
+var code = args[0];
+var fileName = args[1];
+var fileMap = JSON.parse(args[2]);
+
+var dirName = path.dirname(fileName);
+
+var script = vm.runInThisContext(m.wrap(code), fileName).bind(global);
+script(exports, patchRequire(dirName, fileMap), module, fileName, dirName);
+
+var newKeys = Object.keys(global).filter(function(key){
+  return keysBefore.indexOf(key) === -1;
+});
+
+process.on('beforeExit', function(){
+  process.send(newKeys.reduce(function(results, newKey){
+    results[newKey] = global[newKey];
+    return results;
+  }, {}));
+});

--- a/index.js
+++ b/index.js
@@ -1,11 +1,42 @@
 'use strict';
 
-var spawn = require('child_process').spawn;
+var fork = require('child_process').fork;
+var path = require('path');
 var through = require('through2');
+var merge = require('lodash.merge');
 var PluginError = require('gulp-util').PluginError;
+var entry = path.resolve(__dirname, './fork.js');
 
 function createError(payload) {
   return new PluginError('gulp-tape', payload);
+}
+
+function getTestRunner(reporter, outputStream, map, callback) {
+  return through.obj(function(file, encoding, cb) {
+    if (file.isNull()) {
+      return cb(null, file);
+    }
+
+    if (file.isStream()) {
+      return cb(createError('Streaming is not supported'));
+    }
+
+    fork(entry, [file.contents.toString(), file.path, JSON.stringify(map || {})], {
+      silent: true
+    }).on('error', function(err){
+        console.error(err);
+        cb(createError(err));
+      })
+      .on('exit', function(code){
+        if (code !== 0) {
+          return cb(createError(file.path + ' exited with non-zero code: ' + code));
+        }
+        cb(null, file);
+      })
+      .on('message', function(payload){
+        merge(global, payload);
+      }).stdout.pipe(reporter).pipe(outputStream);
+  }, callback);
 }
 
 function gulpTape(opts) {
@@ -13,27 +44,22 @@ function gulpTape(opts) {
 
   var outputStream = opts.outputStream || process.stdout;
   var reporter     = opts.reporter     || through.obj();
+  var exec         = opts.exec;
 
-  return through.obj(function(file, encoding, cb) {
-    if (file.isNull()) {
-      return cb(null, file);
-    }
-    if (file.isStream()) {
-      return cb(createError('Streaming is not supported'));
-    }
+  if (!exec) {
+    return getTestRunner(reporter, outputStream);
+  } else {
+    var map = {};
 
-    spawn('node', [file.path])
-      .on('error', function(err){
-        cb(createError(err));
-      })
-      .on('exit', function(code){
-        if (code !== 0) {
-          return cb(createError(file.path + ' exited with non-zero code: ' + code));
-        }
-        cb();
-      })
-      .stdout.pipe(reporter).pipe(outputStream);
-  });
+    return through.obj(function(file, encoding, cb){
+      map[file.path] = file.contents.toString();
+      cb(null, file);
+    }, function(callback){
+      exec.pipe(getTestRunner(reporter, outputStream, map, function(){
+        callback();
+      })).on('error', callback);
+    });
+  }
 }
 
 module.exports = gulpTape;

--- a/index.js
+++ b/index.js
@@ -1,54 +1,39 @@
 'use strict';
 
-var tape = require('tape');
+var spawn = require('child_process').spawn;
 var through = require('through2');
 var PluginError = require('gulp-util').PluginError;
-var requireUncached = require('require-uncached');
 
-var PLUGIN_NAME = 'gulp-tape';
+function createError(payload) {
+  return new PluginError('gulp-tape', payload);
+}
 
-var gulpTape = function(opts) {
+function gulpTape(opts) {
   opts = opts || {};
 
   var outputStream = opts.outputStream || process.stdout;
   var reporter     = opts.reporter     || through.obj();
-  var files        = [];
 
-  var transform = function(file, encoding, cb) {
+  return through.obj(function(file, encoding, cb) {
     if (file.isNull()) {
       return cb(null, file);
     }
     if (file.isStream()) {
-      return cb(new PluginError(PLUGIN_NAME, 'Streaming is not supported'));
+      return cb(createError('Streaming is not supported'));
     }
-    files.push(file.path);
-    cb(null, file);
-  };
 
-  var flush = function(cb) {
-    try {
-      tape.createStream().pipe(reporter).pipe(outputStream);
-      files.forEach(function(file) {
-        requireUncached(file);
-      });
-      var tests = tape.getHarness()._tests;
-      var pending = tests.length;
-      if (pending === 0) {
-        return cb();
-      }
-      tests.forEach(function(test) {
-        test.once('end', function() {
-          if (--pending === 0) {
-            cb();
-          }
-        });
-      });
-    } catch (err) {
-      cb(new PluginError(PLUGIN_NAME, err));
-    }
-  };
-
-  return through.obj(transform, flush);
-};
+    spawn('node', [file.path])
+      .on('error', function(err){
+        cb(createError(err));
+      })
+      .on('exit', function(code){
+        if (code !== 0) {
+          return cb(createError(file.path + ' exited with non-zero code: ' + code));
+        }
+        cb();
+      })
+      .stdout.pipe(reporter).pipe(outputStream);
+  });
+}
 
 module.exports = gulpTape;

--- a/package.json
+++ b/package.json
@@ -10,15 +10,14 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "require-uncached": "^1.0.2",
-    "tape": "^4.2.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-istanbul": "^0.10.1",
     "jshint": "^2.8.0",
-    "tap-colorize": "^1.2.0"
+    "tap-colorize": "^1.2.0",
+    "tape": "^4.2.2"
   },
   "scripts": {
     "build": "npm run lint && npm test",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "tap-colorize": "^1.2.0",
     "tape": "^4.2.2"
   },
+  "peerDependencies": {
+    "tape": "*"
+  },
   "scripts": {
     "build": "npm run lint && npm test",
     "lint": "jshint --verbose index.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.6",
+    "lodash.merge": "^3.3.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test/fixtures/test/index.js
+++ b/test/fixtures/test/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var test = require('tape');
-var abs = require('../');
+var abs = require('../index.js');
+
 
 test('negative', function(t) {
   t.equal(abs(-1), 1);
@@ -10,5 +11,8 @@ test('negative', function(t) {
 
 test('positive', function(t) {
   t.equal(abs(1), 1);
-  t.end();
+
+  setTimeout(function(){
+    t.end();
+  }, 1000);
 });

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -13,27 +13,38 @@ gulp.task('test', function() {
     }));
 });
 
+'use strict';
+
+var gulp = require('gulp');
+var istanbul = require('gulp-istanbul');
+var tapColorize = require('tap-colorize');
+
+var tape = require('../');
+
+gulp.task('test', function() {
+  return gulp.src('fixtures/test/*.js')
+    .pipe(tape({
+      reporter: tapColorize()
+    }));
+});
+
 gulp.task('istanbul', function(cb) {
-  gulp.src('fixtures/*.js')
+  return gulp.src('fixtures/*.js')
     .pipe(istanbul())
-    .pipe(istanbul.hookRequire())
-    .on('finish', function() {
-      gulp.src('fixtures/test/*.js')
-        .on('error', cb)
-        .on('end', cb)
-        .pipe(tape())
-        .pipe(istanbul.writeReports({
-          reporters: ['lcov', 'text']
-        }))
-        .pipe(istanbul.enforceThresholds({
-          thresholds: {
-            global: {
-              statements: 83,
-              functions: 90,
-              branches: 75,
-              lines: 83,
-            },
-          },
-        }));
-    });
+    .pipe(tape({
+      'exec': gulp.src('fixtures/test/*.js')
+    }))
+    .pipe(istanbul.writeReports({
+      reporters: ['lcov', 'text']
+    }))
+    .pipe(istanbul.enforceThresholds({
+      thresholds: {
+        global: {
+          statements: 83,
+          functions: 90,
+          branches: 75,
+          lines: 83
+        }
+      }
+    }));
 });


### PR DESCRIPTION
This
- Simplifies the detection of completed test-runs by using `child_process.fork` instead of manual counting executed tests
- Removes the need to check on a private property of `tape.testHarness` instances
- ~~Saves ~40% LOC~~
- Does away with the `require-uncached` dependency
- Adds `lodash.merge` as dependency
- Adds tape as peerDependency and devDependency
- Allows for removal of the direct tape dependency and installation of whatever version users choose 
- ~~Requires users to install `tape` along `gulp-tape`. Specifying `tape: "*"` as peerDependency could be beneficial~~ 
- Runs tests in parallelizable forked processes
- Correctly propagates global variables used by coverage tools back to the main process
