### PR TITLE
Allow consumers to provide options that are forwarded to tape

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var gulpTape = function(opts) {
 
   var outputStream = opts.outputStream || process.stdout;
   var reporter     = opts.reporter     || through.obj();
+  var tapeOpts     = opts.tapeOpts     || {};
   var files        = [];
 
   var transform = function(file, encoding, cb) {
@@ -27,7 +28,7 @@ var gulpTape = function(opts) {
 
   var flush = function(cb) {
     try {
-      tape.createStream().pipe(reporter).pipe(outputStream);
+      tape.createStream(tapeOpts).pipe(reporter).pipe(outputStream);
       files.forEach(function(file) {
         requireUncached(file);
       });


### PR DESCRIPTION
Most tape reporters are to be piped to from the command-line (and for me, they do not play very nicely with gulp and the Task Runner in Visual Studio :-1: ). 

If you can pass on options to tape, more specifically [`{ objectMode: true }`](https://github.com/substack/tape#object-stream-reporter) then the threshold for developing your own reporter is much lower.
