### PR TITLE
End the output stream when the harness closes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,17 +32,18 @@ var gulpTape = function(opts) {
       files.forEach(function(file) {
         requireUncached(file);
       });
-      var tests = tape.getHarness()._tests;
-      var pending = tests.length;
-      if (pending === 0) {
-        return cb();
-      }
-      tests.forEach(function(test) {
-        test.once('end', function() {
-          if (--pending === 0) {
-            cb();
-          }
-        });
+      var closed = false;
+      var harness = tape.getHarness();
+      var results = harness._results;
+      harness.close = function () {
+        if (!closed) {
+          closed = true;
+          results.close();
+          cb();
+        }
+      };
+      results.once('done', function () {
+        harness.close();
       });
     } catch (err) {
       cb(new PluginError(PLUGIN_NAME, err));


### PR DESCRIPTION
It turns out that `tape` still writes something into the stream when tests are done.
I think the appropriate time to end the output stream of `gulp-tape` would be when the `harness` closes.

If `tap-spec` is the specified reporter, and we end the stream when tests `done`, the output would be something like:

```
[13:41:39] Starting 'test'...

  negative

    ✔ should be equal

  positive

    ✔ should be equal
[13:41:39] Finished 'test' after 33 ms
```

However, if we end the stream when the harness `close`:

```
[13:40:06] Starting 'test'...

  negative

    ✔ should be equal

  positive

    ✔ should be equal


  total:     2
  passing:   2
  duration:  28ms


[13:40:06] Finished 'test' after 41 ms
```

The original `tape` harness wouldn't `close` in node until the process exits.
However, gulp tasks could continue when tests are done.
So, I `close` the harness when `done`, so that all messages from `tape` have been written into the reporter before the output stream ends.
