### PR TITLE
End the stream created when done

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ var gulpTape = function(opts) {
           write('\n# ok\n');
         }
 
+        // Reset the results status
+        this.count = 0;
+        this.fail = 0;
+        this.pass = 0;
+        this.tests.length = 0;
+
         tapeOutput.push(null);
 
         cb();

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ var gulpTape = function(opts) {
 
   var flush = function(cb) {
     try {
-      var tapeOutput = tape.createStream(tapeOpts);
-      tapeOutput.pipe(reporter).pipe(outputStream);
+      var tapeStream = tape.createStream(tapeOpts);
+      tapeStream.pipe(reporter).pipe(outputStream);
       files.forEach(function(file) {
         requireUncached(file);
       });
@@ -52,9 +52,8 @@ var gulpTape = function(opts) {
         this.count = 0;
         this.fail = 0;
         this.pass = 0;
-        this.tests.length = 0;
 
-        tapeOutput.push(null);
+        tapeStream.push(null);
 
         cb();
       });

--- a/index.js
+++ b/index.js
@@ -35,7 +35,21 @@ var gulpTape = function(opts) {
       });
       var results = tape.getHarness()._results;
       results.once('done', function () {
+
+        // The following messages will never reach the reporter,
+        // if we end the tape output here.
+        var write = this._stream.push.bind(this._stream);
+        write('\n1..' + this.count + '\n');
+        write('# tests ' + this.count + '\n');
+        write('# pass  ' + this.pass + '\n');
+        if (this.fail) {
+          write('# fail  ' + this.fail + '\n');
+        } else {
+          write('\n# ok\n');
+        }
+
         tapeOutput.push(null);
+
         cb();
       });
 


### PR DESCRIPTION
Fix #10 and #8 

The reason why the test task never ends in watch mode, is that `tape.getHarness()._tests.length` increases each time the test task finishes. So from the second time, it never ends.

I end the tape output when tests are done, so that the reporter output will come before the gulp task messages and they won't mess.
However, the reporter will never receive messages created when `results.close` called. So I push them manually. 

I'm not quite sure whether we should end the tape output and push the extra messages.
What do you say? @yuanqing 
