### PR TITLE
Added support to failOnError

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ var tape = require('gulp-tape');
 
 - `tapeOpts` &mdash; The options passed to [`tape.createStream`](https://github.com/substack/tape#var-stream--testcreatestreamopts).
 
+- `bail` &mdash; Whether to stop the Gulp process on the first failing assertion. Defaults to `false`.
+
 ## Installation
 
 Install via [npm](https://npmjs.com/) (together with [Tape](https://github.com/substack/tape)):

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var gulpTape = function(opts) {
   var outputStream = opts.outputStream || process.stdout;
   var reporter     = opts.reporter     || through.obj();
   var tapeOpts     = opts.tapeOpts     || {};
+  var bail         = opts.bail  || false;
   var files        = [];
 
   var transform = function(file, encoding, cb) {
@@ -44,6 +45,10 @@ var gulpTape = function(opts) {
         write('# pass  ' + this.pass + '\n');
         if (this.fail) {
           write('# fail  ' + this.fail + '\n');
+
+          if (bail) {
+            return cb(new PluginError(PLUGIN_NAME, 'Test failed'));
+          }
         } else {
           write('\n# ok\n');
         }


### PR DESCRIPTION
Added failOnError option that default to false. If true, it bails the test execution in gulp.

I tried adding a test scenario for that, but I was not able to understand how to add assertions in your test. From what I saw, you are actually executing a gulp task when running `npm test`.

Fixes: https://github.com/yuanqing/gulp-tape/issues/15
