### PR TITLE
require cache handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var tape = require('tape');
 var through = require('through2');
 var PluginError = require('gulp-util').PluginError;
-var requireUncached = require('require-uncached');
+var rcc = require('require-cache-control');
 
 var PLUGIN_NAME = 'gulp-tape';
 
@@ -33,7 +33,9 @@ var gulpTape = function(opts) {
       var tapeStream = tape.createStream(tapeOpts);
       tapeStream.pipe(reporter).pipe(outputStream);
       files.forEach(function(file) {
-        requireUncached(file);
+        rcc.snapshot();
+        require(file);
+        rcc.restore();
       });
       var results = tape.getHarness()._results;
       results.once('done', function() {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
-    "require-uncached": "^1.0.2",
+    "require-cache-control": "^0.1.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
requireUncached(file) just loads a fresh copy of the _file_.

If _file_ requires other files, like a fooSpec.js loading the actual code foo.js, foo.js will always be cached because requireUncached(file) only invalidates the cache for the _file_.

This patch fixes that.
